### PR TITLE
59_管理機能を実装（５）親カテゴリーの管理画面を実装

### DIFF
--- a/src/app/Category.php
+++ b/src/app/Category.php
@@ -10,4 +10,9 @@ class Category extends Model
     {
         return $this->hasMany('App\Product'); // todo: Category : Product = 1 : 多
     }
+
+    public function major_category()
+    {
+        return $this->belongsTo('App\MajorCategory');
+    }
 }

--- a/src/app/Http/Controllers/Dashboard/MajorCategoryController.php
+++ b/src/app/Http/Controllers/Dashboard/MajorCategoryController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\MajorCategory;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+class MajorCategoryController extends Controller
+{
+
+    public function index()
+    {
+        $major_categories = MajorCategory::paginate(15);
+
+        return view('dashboard.major_categories.index', compact('major_categories'));
+    }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate(
+            [
+                'name'        => 'required|unique:major_categories',
+                'description' => 'required',
+            ],
+            [
+                'name.required'        => '親カテゴリ名は必須です。',
+                'name.unique'          => '親カテゴリ名「' . $request->input('name') . '」は登録済みです。',
+                'description.required' => '親カテゴリの説明は必須です。',
+            ]
+        );
+
+        $major_category = new MajorCategory();
+        $major_category->name = $request->input('name');
+        $major_category->description = $request->input('description');
+        $major_category->save();
+
+        return redirect("/dashboard/major_categories");
+
+    }
+
+    public function show(MajorCategory $majorCategory)
+    {
+        //
+    }
+
+    public function edit(MajorCategory $major_category)
+    {
+        return view('dashboard.major_categories.edit', compact('major_category'));
+    }
+
+    public function update(Request $request, MajorCategory $major_category)
+    {
+        $request->validate(
+            [
+                'name'        => 'required|unique:major_categories',
+                'description' => 'required',
+            ],
+            [
+                'name.required'        => '親カテゴリ名は必須です。',
+                'name.unique'          => '親カテゴリ名「' . $request->input('name') . '」は登録済みです。',
+                'description.required' => '親カテゴリの説明は必須です。',
+            ]
+        );
+
+        $major_category->name = $request->input('name');
+        $major_category->description = $request->input('description');
+        $major_category->update();
+
+        return redirect("/dashboard/major_categories");
+    }
+
+    public function destroy(MajorCategory $major_category)
+    {
+        $major_category->delete();
+
+        return redirect("/dashboard/major_categories");
+    }
+}

--- a/src/app/MajorCategory.php
+++ b/src/app/MajorCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MajorCategory extends Model
+{
+    public function categories()
+    {
+        return $this->hasMany('App\Category');
+    }
+}

--- a/src/database/migrations/2022_02_05_194829_create_major_categories_table.php
+++ b/src/database/migrations/2022_02_05_194829_create_major_categories_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMajorCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('major_categories', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->text('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('major_categories');
+    }
+}

--- a/src/database/migrations/2022_02_05_195052_add_major_category_to_categories.php
+++ b/src/database/migrations/2022_02_05_195052_add_major_category_to_categories.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddMajorCategoryToCategories extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->integer('major_category_id')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/src/database/seeds/MajorCategoriesSeeder.php
+++ b/src/database/seeds/MajorCategoriesSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\MajorCategory;
+
+class MajorCategoriesSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $major_category_names = [
+            '本', 'コンピュータ', 'ディスプレイ'
+        ];
+
+        foreach ($major_category_names as $major_category_name) {
+            MajorCategory::create(
+                [
+                    'name'        => $major_category_name,
+                    'description' => $major_category_name,
+                ]
+            );
+        }
+    }
+}

--- a/src/resources/views/components/dashboard/sidebar.blade.php
+++ b/src/resources/views/components/dashboard/sidebar.blade.php
@@ -9,7 +9,9 @@
         <label class="samazon-sidebar-category-label">
             <a href="/dashboard/products">商品一覧</a>
         </label>
-        <label class="samazon-sidebar-category-label">親カテゴリ管理</label>
+        <label class="samazon-sidebar-category-label">
+            <a href="/dashboard/major_categories">親カテゴリ管理</a>
+        </label>
         <label class="samazon-sidebar-category-label">
             <a href="/dashboard/categories">カテゴリ管理</a>
         </label>

--- a/src/resources/views/dashboard/major_categories/edit.blade.php
+++ b/src/resources/views/dashboard/major_categories/edit.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.dashboard')
+
+@section('content')
+    <div class="w-75">
+        <h1>カテゴリ情報更新</h1>
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul>
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        <form method="POST" action="/dashboard/major_categories/{{ $major_category->id }}" class="mb-4">
+            {{ csrf_field() }}
+            <input type="hidden" name="_method" value="PUT">
+            <div class="form-group">
+                <label for="major-category-name">カテゴリ名</label>
+                <input type="text" name="name" id="major-category-name" class="form-control" value="{{ $major_category->name }}">
+            </div>
+            <div class="form-group">
+                <label for="major-category-description">カテゴリの説明</label>
+                <textarea name="description" id="major-category-description" class="form-control">{{ $major_category->description }}</textarea>
+            </div>
+            <button type="submit" class="btn samazon-submit-button">更新</button>
+        </form>
+
+        <a href="/dashboard/major_categories">カテゴリ一覧に戻る</a>
+    </div>
+@endsection

--- a/src/resources/views/dashboard/major_categories/index.blade.php
+++ b/src/resources/views/dashboard/major_categories/index.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.dashboard')
+
+@section('content')
+    <div class="w-75">
+        <!--バリデーションエラーの表示-->
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul>
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        <form method="POST" action="/dashboard/major_categories">
+            {{ csrf_field() }}
+            <div class="form-group">
+                <label for="major-category-name">親カテゴリ名</label>
+                <input type="text" name="name" id="major-category-name" class="form-control">
+            </div>
+            <div class="form-group">
+                <label for="major-category-description">親カテゴリの説明</label>
+                <textarea name="description" id="major-category-description" class="form-control"></textarea>
+            </div>
+            <button type="submit" class="btn samazon-submit-button">＋新規作成</button>
+        </form>
+
+        <table class="table mt-5">
+            <thead>
+                <tr>
+                    <th scope="col" class="w-25">ID</th>
+                    <th scope="col">親カテゴリ</th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($major_categories as $major_category)
+                    <tr>
+                        <th scope="row">{{ $major_category->id }}</td>
+                        <td>{{ $major_category->name }}</td>
+                        <td>
+                            <a href="/dashboard/major_categories/{{ $major_category->id }}/edit" class="dashboard-edit-link">編集</a>
+                        </td>
+                        <td>
+                            <a href="/dashboard/major_categories/{{ $major_category->id }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();" class="dashboard-delete-link">
+                                削除
+                            </a>
+
+                            <form id="logout-form" action="/dashboard/major_categories/{{ $major_category->id }}" method="POST" style="display: none;">
+                                @csrf
+                                <input type="hidden" name="_method" value="DELETE">
+                            </form>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        {{ $major_categories->links() }}
+    </div>
+@endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -43,6 +43,7 @@ Route::get('/dashboard', 'DashboardController@index')->middleware('auth:admins')
 Route::group(['prefix' => 'dashboard', 'as' => 'dashboard.'], function () {
     Route::get('login', 'Dashboard\Auth\LoginController@showLoginForm')->name('login');
     Route::post('login', 'Dashboard\Auth\LoginController@login')->name('login');
+    Route::resource('major_categories', 'Dashboard\MajorCategoryController')->middleware('auth:admins');
     Route::resource('categories', 'Dashboard\CategoryController')->middleware('auth:admins');
     Route::resource('products', 'Dashboard\ProductController')->middleware('auth:admins');
 });


### PR DESCRIPTION
- php artisan make:model MajorCategory -m
- マイグレーションファイル編集
- 親カテゴリーと子カテゴリーのリレーションを設定
- php artisan make:migration add_major_category_to_categories
- マイグレーションファイル編集
- php artisan make:controller --resource Dashboard/MajorCategoryController --model=MajorCategory　親カテゴリー用のコントローラーを作成
- MajorCategoryコントローラー編集
- 親カテゴリ用のビューを作成
- ルーティングを設定
- 親カテゴリー管理画面へのリンク作成
- 親カテゴリーのシーダを作成